### PR TITLE
MIT-2050: Update activation webhook documentation with USD conversion fields

### DIFF
--- a/docs/Other/marketplace_webhooks.md
+++ b/docs/Other/marketplace_webhooks.md
@@ -109,8 +109,13 @@ Details:
 - **activation_id:** _Unique id specific to each instance of an activated product._
 - **order_form_submission_id** _A unique identifier specific to the order form that was filled out. Will be empty if there is no order form.
 - **vendor_order_id** _A unique identifier for the order the product was purchased in._
-- **variable_price** _A nested structure representing what is being spent on the product at activation. The structure contains values for currency, frequency of billing and the spending amount in cents. 
-As well as the original spending amount converted to your currency, plus the conversion rate used._
+- **variable_price** _A nested structure representing what is being spent on the product at activation.
+    - **value** _The original spend value/budget in cents, before currency conversion._
+    - **currency** _The original currency in which the spend/budget._
+    - **frequency** _The frequency of the spend value_
+    - **conversion_value** _The spend value/budget in cents, after currency conversion._
+    - **conversion_currency** _The currency that the original spend/budget is converted to_,
+    - **conversion_rate** _The conversion rate used to convert `value` to obtain the `conversion_value`._
 - **edition_id** _A unique identifier for the edition of the product being purchased. Will be empty if product does not have separate editions._
 - **app_id** _A unique identifier for the product._
 

--- a/docs/Other/marketplace_webhooks.md
+++ b/docs/Other/marketplace_webhooks.md
@@ -109,12 +109,16 @@ Details:
 - **activation_id:** _Unique id specific to each instance of an activated product._
 - **order_form_submission_id** _A unique identifier specific to the order form that was filled out. Will be empty if there is no order form.
 - **vendor_order_id** _A unique identifier for the order the product was purchased in._
-- **variable_price** _A nested structure representing what is being spent on the product at activation.
-    - **value** _The original spend value/budget in cents, before currency conversion._
-    - **currency** _The original currency in which the spend/budget._
-    - **frequency** _The frequency of the spend value_
-    - **conversion_value** _The spend value/budget in cents, after currency conversion._
-    - **conversion_currency** _The currency that the original spend/budget is converted to_,
+- **variable_price** _A nested structure representing what is being spent on the product at activation._
+  Received from reseller
+    - **value** _The amount of the original spend in cents (or smallest denomination in other currencies), before currency conversion._
+    - **currency** _The currency of the original spend._
+    - **frequency** _The frequency of the spend value._
+
+  Sent to vendor
+
+    - **conversion_value** _The amount of the original spend in cents (or smallest denomination in other currencies) after conversion from the requested_value._
+    - **conversion_currency** _The currency that the original spend is converted to._
     - **conversion_rate** _The conversion rate used to convert `value` to obtain the `conversion_value`._
 - **edition_id** _A unique identifier for the edition of the product being purchased. Will be empty if product does not have separate editions._
 - **app_id** _A unique identifier for the product._

--- a/docs/Other/marketplace_webhooks.md
+++ b/docs/Other/marketplace_webhooks.md
@@ -109,7 +109,8 @@ Details:
 - **activation_id:** _Unique id specific to each instance of an activated product._
 - **order_form_submission_id** _A unique identifier specific to the order form that was filled out. Will be empty if there is no order form.
 - **vendor_order_id** _A unique identifier for the order the product was purchased in._
-- **variable_price** _A nested structure representing what is being spent on the product at activation. The structure contains values for currency, frequency of billing and the spending amount in cents._
+- **variable_price** _A nested structure representing what is being spent on the product at activation. The structure contains values for currency, frequency of billing and the spending amount in cents. 
+As well as the original spending amount converted to your currency, plus the conversion rate used._
 - **edition_id** _A unique identifier for the edition of the product being purchased. Will be empty if product does not have separate editions._
 - **app_id** _A unique identifier for the product._
 
@@ -224,9 +225,12 @@ title: Provision Event
       "order_form_submission_id":"OFS-9f2e1a82-51d6-4a79-ba4b-a8347de14e53",
       "vendor_order_id":"ORD-XXXXXXXXXX",
       "variable_price":{
-         "currency":"USD",
-         "value":50000,
-         "frequency":"MONTHLY"
+         "currency":"CAD",
+         "value":14000,
+         "frequency":"MONTHLY",
+         "conversion_value": 10000,
+         "conversion_currency": "USD",
+         "conversion_rate": 1.4
       },
       "edition_id":"EDITION-123",
       "app_id":"MP-123"


### PR DESCRIPTION
Update activation webhook documentation with USD conversion fields

https://vendasta.jira.com/wiki/spaces/CKD/pages/1880230719/Options+to+include+USD+conversion+in+Vendor+Webhooks

https://vendasta.jira.com/browse/MIT-2050
@ncline-va 
@vendasta/marketplace-institute-of-technology 