### PR TITLE
[MIT-2060] fix: put headers on their own lines

### DIFF
--- a/docs/Other/marketplace_webhooks.md
+++ b/docs/Other/marketplace_webhooks.md
@@ -117,12 +117,12 @@ Details:
     other products, Vendasta only pays vendors in USD. The currency related fields below are used to provide transparency
     (to vendors) in cross currency variable priced purchases.
 
-    Received from reseller
+Received from reseller
   - **value** _The amount of the original spend in cents (or smallest denomination in other currencies), before currency conversion._
   - **currency** _The currency of the original spend._
   - **frequency** _The frequency of the spend value._
 
-    Sent to vendor
+  Sent to vendor
   - **converted_value** _The amount of the original spend in cents (or smallest denomination in other currencies) after conversion from the `value`._
   - **conversion_currency** _The currency that the original spend is converted to._
   - **conversion_rate** _The conversion rate used to convert `value` to obtain the `converted_value`._

--- a/docs/Other/marketplace_webhooks.md
+++ b/docs/Other/marketplace_webhooks.md
@@ -113,11 +113,12 @@ Details:
 - **app_id** _A unique identifier for the product._
 - **variable_price** _A nested structure representing what is being spent on the product at activation._
 
-    We always convert non-USD values to USD. While partners can pay in USD, AUD, or CAD for digital ads and potentially
-    other products, Vendasta only pays vendors in USD. The currency related fields below are used to provide transparency
-    (to vendors) in cross currency variable priced purchases.
 
-Received from reseller
+  We always convert non-USD values to USD. While partners can pay in USD, AUD, or CAD for digital ads and potentially
+  other products, Vendasta only pays vendors in USD. The currency related fields below are used to provide transparency
+  (to vendors) in cross currency variable priced purchases.
+
+  Received from reseller
   - **value** _The amount of the original spend in cents (or smallest denomination in other currencies), before currency conversion._
   - **currency** _The currency of the original spend._
   - **frequency** _The frequency of the spend value._


### PR DESCRIPTION
Fix formatting for "received from reseller" and "sent to vendor" headers and paragraph about currency conversion

Before:
![image](https://user-images.githubusercontent.com/54858313/205099050-4f0aca8d-1eae-4402-bc44-bc7dbac5e644.png)

After:
![image](https://user-images.githubusercontent.com/54858313/205099801-b303bbd3-d3d8-4dfa-9ed5-4e7786f1baec.png)

@vendasta/marketplace-institute-of-technology 