### PR TITLE
chore(spectral): remove unneeded token

### DIFF
--- a/.spectral.mjs
+++ b/.spectral.mjs
@@ -1,2 +1,2 @@
-import ruleset from "https://stoplight.io/api/v1/projects/cHJqOjc1MTQ4/spectral.js?branch_slug=master&token=6a994d97-a111-4816-8ab7-ca0ff5230b8d";
+import ruleset from "https://stoplight.io/api/v1/projects/cHJqOjc1MTQ4/spectral.js?branch_slug=master";
 export default { extends: ruleset };


### PR DESCRIPTION
### Problem
A HackerOne report was created detailing apparent API tokens disclosed in plaintext.

### Solution
The token doesn't appear to be needed for accessing the spectral.js file, nor does it seem to grant access to any sensitive files or API endpoints (it may have been needed at one point when this file was private?). To avoid future reports, I am removing it. If we do find out where this token came from, we can probably delete it or rotate it if required.

@richard-rance @ncline-va 