### PR TITLE
MT-2164: Update /change_spend/resolve api accepted response to 200

### DIFF
--- a/reference/marketplace-api.yaml
+++ b/reference/marketplace-api.yaml
@@ -1194,7 +1194,7 @@ paths:
       tags:
         - change_spend
       responses:
-        '202':
+        '200':
           description: Accepted
         '400':
           description: Bad request - invalid parameters in the body of the request


### PR DESCRIPTION
The marketplace api for resolving spend change request returns a `200` response code, but the documentation says it returns `202`
https://developers.vendasta.com/vendor/fb083d5d277b7-resolve-a-change-spend-request-by-approving-or-rejecting
<img width="740" alt="image" src="https://github.com/user-attachments/assets/95a5384e-d371-4234-8e8d-b5a9d2359817">
 

https://vendasta.jira.com/browse/MT-2164
@vendasta/marketplace-institute-of-technology 
@ncline-va 
